### PR TITLE
Allow pause to accept optional payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ It's possible to control the chromecasts, by sending a message to the `<MQTT_ROO
 | Action | Payload required | Value for payload |
 | ------ | ------- | ----------------- |
 | play | Optional | If no payload, just starts from a pause condition, otherwise send a json object {"link":string, "type": string} |
-| pause | No | |
+| pause | Optional | If no payload is supplied it will toggle pause state, otherwise send 1/True to pause or 0/False to play |
 | stop | No | |
 | next | No | |
 | prev | No | |

--- a/chrome2mqtt/command.py
+++ b/chrome2mqtt/command.py
@@ -49,9 +49,20 @@ class Command:
         self.device.media_controller.stop()
         self.status.clear()
 
-    def pause(self):
+    def pause(self, pause):
         """ Pause playback """
-        self.device.media_controller.pause()
+        pause = pause.lower()
+        if (pause is None or pause == ''):
+            if (self.status.pause):
+                self.device.media_controller.play()
+            else:
+                self.device.media_controller.pause()
+        elif (pause == '1' or pause == 'true'):
+            self.device.media_controller.pause()
+        elif (pause == '0' or pause == 'false'):
+            self.device.media_controller.play()
+        else:
+            raise CommandException('Pause could not match "{0}" as a parameter'.format(pause))
 
     def fwd(self):
         self.log.warn('fwd is a deprecated function, use next instead')


### PR DESCRIPTION
This is a proposed change related to the new command layout feature (https://github.com/tbowmo/chromecastcontrol/pull/12) and the example Homebridge mqttthing device configuration, which I posted earlier in the volume control issue (https://github.com/tbowmo/chromecastcontrol/pull/4).

I'm using Chromecastcontrol with [Homebridge-mqttthing](https://github.com/arachnetech/homebridge-mqttthing) and the "Lightbulb" device. The device has a setOn property which can be used to toggle play vs. pause. The `setOn` topic is limited to a string property, so I can't dynamically change the topic name. Therefore, the only way to tell it to use On (i.e. 'Play') vs. Off (i.e. 'Pause'), is by sending a different message payload.

This change augments the pause command to also perform an "unpause" (play). It keeps the functionality more in-line with other state toggles like Mute and allows me to use homebridge-mqttthing. My config now looks like this:

```json
        {
            "accessory": "mqttthing",
            "type": "lightbulb",
            "name": "Chromecast",
            "url": "mqtt://10.9.1.1",
            "logMqtt": true,
            "onValue": "PLAYING",
            "offValue": "PAUSED",
            "topics": {
                "getOn": "chromecast2mqtt/mira/state",
                "setOn": {
                    "topic": "chromecast2mqtt/mira/control/pause",
                    "apply": "return message == 'PLAYING' ? 'False' : 'True';"
                },
                "getBrightness": "chromecast2mqtt/mira/volume",
                "setBrightness": "chromecast2mqtt/mira/control/volume"
            }
        }
```
