### PR TITLE
Fix Dockerfile by copying additional requirement files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.7.4-slim
 WORKDIR /usr/src/app
 COPY requirements.txt ./
+COPY requirements ./requirements
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Then in a terminal, execute the following two commands to enable your new servic
 
 Start in a docker container
 ---
-If you wish to run inside a docker container, you can build your own image with `docker build . --tag chrome2mqtt` and then run it with `docker run chrome2mqtt <options>` 
+If you wish to run inside a docker container, you can build your own image with `docker build . --tag chrome2mqtt` and then run it with `docker run --network=host chrome2mqtt <options>` 
 
 Command line options
 -------------


### PR DESCRIPTION
requirements.txt points to prod.txt, which isn't copied to the Docker image. This commit fixes that.

Additionally, document that you need to use 'host' networking in Docker (or otherwise do something like [this](https://community.home-assistant.io/t/google-cast-with-docker-no-google-cast-devices-found/145331/24))